### PR TITLE
docs: Readme/Usage org idea

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,52 +128,6 @@ After creating a studio flow, you can make changes to your infrastructure by cha
 
 For more examples checkout the [documentation in the usage.md](usage.md) and the [examples folder](examples).
 
-### Specify a Region and/or Edge
-
-You can define the [Edge](https://www.twilio.com/docs/global-infrastructure/edge-locations#public-edge-locations) and/or [Region](https://www.twilio.com/docs/global-infrastructure/edge-locations/legacy-regions) by setting the environment variables TWILIO_EDGE and/or TWILIO_REGION. However, the resource configuration in your Terraform configuration file take precedence.
-
-```terraform
-provider "twilio" {
-  account_sid = "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  auth_token  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  region = "au1"
-  edge = "sydney"
-}
-```
-
-This will result in the hostname transforming from api.twilio.com to api.sydney.au1.twilio.com.
-
-A Twilio client constructed without these parameters will also look for TWILIO_REGION and TWILIO_EDGE variables inside the current environment.
-
-### Specify Subaccount for v2010 APIs
-
-You can specify a subaccount to use with the provider by either setting the `TWILIO_SUBACCOUNT_SID` environment variable or explicitly passing it to the provider like so:
-
-```terraform
-provider "twilio" {
-  // account_sid defaults to TWILIO_ACCOUNT_SID env var
-  // auth_token  defaults to TWILIO_AUTH_TOKEN env var
-  // subaccount_sid  defaults to TWILIO_SUBACCOUNT_SID env var
-}
-```
-
-```terraform
-provider "twilio" {
-  account_sid    = "AC00112233445566778899aabbccddeefe"
-  auth_token    = "12345678123456781234567812345678"
-  subaccount_sid = "AC00112233445566778899aabbccddeeff"
-}
-```
-
-Alternatively, you can specify the subaccount to use at the resource level:
-
-```terraform
-resource "twilio_api_accounts_keys_v2010" "key_name" {
-  path_account_sid = "AC00112233445566778899aabbccddeeff"
-  friendly_name = "subaccount key"
-}
-```
-
 ### Importing an existing Flex project
 
 For guidance on how to import resources from an existing Flex project, please reference our [Flex example documentation](examples/flex/v1/README.md).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ make build
 1. Run `make install` to install and build the twilio-terraform-provider.
 2. Configure the Twilio provider with your twilio credentials in your Terraform configuration file (e.g. main.tf). These can also be set via `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` environment variables.
 3. Add your resource configurations to your Terraform configuration file (e.g. main.tf).
+
 ```terraform
 terraform {
   required_providers {
@@ -58,6 +59,7 @@ output "messages" {
   value = twilio_api_accounts_keys_v2010.key_name
 }
 ```
+
 4. Run `terraform init` and `terraform apply`to initialize and apply changes to your twilio infrastructure.
 
 ### Create and Delete API Keys
@@ -98,9 +100,27 @@ resource "twilio_api_accounts_incoming_phone_numbers_v2010" "import_purchased_nu
 ```terraform
 resource "twilio_studio_flows_v2" "studio_flow" {
   commit_message = "first draft"
-  friendly_name = "terraform flow"
-  status = "draft"
-  definition = "{\"description\": \"A New Flow\", \"states\": [{\"name\": \"Trigger\", \"type\": \"trigger\", \"transitions\": [], \"properties\": {\"offset\": {\"x\": 0, \"y\": 0}}}], \"initial_state\": \"Trigger\", \"flags\": {\"allow_concurrent_calls\": true}}"
+  friendly_name  = "terraform flow"
+  status         = "draft"
+  definition = jsonencode({
+    description = "A New Flow",
+    states = [
+      {
+        name        = "Trigger"
+        type        = "trigger"
+        transitions = []
+        properties  = {
+          offset = {
+            x = 0
+            y = 0
+          }
+        }
+    }]
+    initial_state = "Trigger"
+    flags = {
+      allow_concurrent_calls = true
+    }
+  })
 }
 ```
 
@@ -161,13 +181,15 @@ For guidance on how to import resources from an existing Flex project, please re
 ## Developing the Provider
 
 The boilerplate includes the following:
+
 - `Makefile` contains helper functions used to build, package and install the Twilio Terraform Provider. It's currently written for MacOS Terraform provider development, but you can change the variables at the top of the file to match your OS_ARCH.
 
   The `install` function is configured to install the provider into the ~/.terraform.d/plugins/ folder.
+
 - `examples` contains sample Terraform configuration that can be used to test the Twilio provider
 - `twilio` contains the main provider code. This will be where the provider's resources and data source implementations will be defined.
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.15+ is *required*).
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.15+ is _required_).
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
@@ -180,12 +202,14 @@ $GOPATH/bin/terraform-provider-twilio
 
 In order to run the full suite of Acceptance tests, run `make testacc`. Provide your Account SID and Auth Token as environment variables to properly configure the test suite.
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+_Note:_ Acceptance tests create real resources, and often cost money to run.
 
 ```sh
  make testacc ACCOUNT_SID=YOUR_ACCOUNT_SID AUTH_TOKEN=YOUR_AUTH_TOKEN
 ```
+
 You can also specify a particular suite to run like so:
+
 ```shell
  make testacc TEST=./twilio/ ACCOUNT_SID=YOUR_ACCOUNT_SID AUTH_TOKEN=YOUR_AUTH_TOKEN
 ```
@@ -195,7 +219,9 @@ An example test file can be found [here](https://github.com/twilio/terraform-pro
 ### Debugging
 
 First:
+
 ```sh
 export TF_LOG=TRACE
 ```
+
 then refer to the [Terraform Debugging Documentation](https://www.terraform.io/docs/internals/debugging.html).

--- a/README.md
+++ b/README.md
@@ -60,77 +60,11 @@ output "messages" {
 }
 ```
 
-4. Run `terraform init` and `terraform apply`to initialize and apply changes to your twilio infrastructure.
+4. Run `terraform init` and `terraform apply` to initialize and apply changes to your Twilio infrastructure.
 
-### Create and Delete API Keys
+## Examples
 
-```terraform
-resource "twilio_api_accounts_keys_v2010" "key_name" {
-  friendly_name = "terraform key"
-}
-
-output "messages" {
-  value = twilio_api_accounts_keys_v2010.key_name
-}
-```
-
-To delete a specific key in your terraform infrastructure you can use the command `terraform destroy -target twilio_api_keys_v2010.<resource name>`. To delete the terraform key created in this example use `terraform destroy -target twilio_api_keys_v2010.key_name`.
-
-### Buy and Configure a Phone Number
-
-```terraform
-resource "twilio_api_incoming_phone_numbers_v2010" "buy_phone_number" {
-  area_code = "415"
-  friendly_name = "terraform phone number"
-  sms_url = "https://demo.twilio.com/welcome/sms/reply"
-  voice_url = "https://demo.twilio.com/docs/voice.xml"
-}
-```
-
-### Import a Twilio Phone Number
-
-```terraform
-resource "twilio_api_accounts_incoming_phone_numbers_v2010" "import_purchased_number" {
-  phone_number = "+14444444444"
-}
-```
-
-### Define a Studio Flow
-
-```terraform
-resource "twilio_studio_flows_v2" "studio_flow" {
-  commit_message = "first draft"
-  friendly_name  = "terraform flow"
-  status         = "draft"
-  definition = jsonencode({
-    description = "A New Flow",
-    states = [
-      {
-        name        = "Trigger"
-        type        = "trigger"
-        transitions = []
-        properties  = {
-          offset = {
-            x = 0
-            y = 0
-          }
-        }
-    }]
-    initial_state = "Trigger"
-    flags = {
-      allow_concurrent_calls = true
-    }
-  })
-}
-```
-
-After creating a studio flow, you can make changes to your infrastructure by changing the values in your configuration file. Run `terraform apply` to apply these changes to your infrastructure.
-
-For more examples checkout the [documentation in the usage.md](usage.md) and the [examples folder](examples).
-
-### Importing an existing Flex project
-
-For guidance on how to import resources from an existing Flex project, please reference our [Flex example documentation](examples/flex/v1/README.md).
+For usage examples, checkout the [documentation in usage.md](usage.md) and the [examples folder](examples).
 
 ## Developing the Provider
 

--- a/usage.md
+++ b/usage.md
@@ -1,14 +1,16 @@
 # Twilio Provider
+
 The Twilio provider is used to interact with the resources supported by Twilio.
 The provider needs to be configured with the proper credentials before it can be used.
 
 - [Twilio Provider](#twilio-provider)
-  * [Example Usage](#example-usage)
-    + [Argument Reference](#argument-reference)
-  * [Example: Create an API key](#example-create-an-api-key)
-  * [Example: Proxy Service](#example-proxy-service)
+  - [Example Usage](#example-usage)
+    - [Argument Reference](#argument-reference)
+  - [Example: Create an API key](#example-create-an-api-key)
+  - [Example: Proxy Service](#example-proxy-service)
 
 ## Example Usage
+
 ```hcl-terraform
 # Configure the Twilio provider
 provider "twilio" {
@@ -28,6 +30,7 @@ resource "twilio_flex_flow" "default" {
 ```
 
 then:
+
 ```bash
 $ terraform init
 $ terraform apply
@@ -35,14 +38,18 @@ $ terraform destroy
 ```
 
 ### Argument Reference
+
 The following arguments are supported:
+
 - `account_sid` - (Required) Twilio Account SID. This can also be set via the `ACCOUNT_SID` environment variable.
 - `auth_token` - (Required) Auth token for the account. This can also be set via the `AUTH_TOKEN` environment variable.
 
 ## Example: Create an API Key
+
 `twilio_api_incoming_phone_numbers_v2010` provides a Twilio Phone Number resource.
 
 ### Usage
+
 ```hcl-terraform
 resource "twilio_api_keys_v2010" "default" {
     account_sid = "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -54,16 +61,19 @@ output "messages" {
 ```
 
 ### Attributes Reference
+
 - `sid` - The unique string that that we created to identify the Key resource.
 - `friendly_name` - The string that you assigned to describe the resource.
 
 For more information see [the API Key documentation](https://www.twilio.com/docs/iam/keys/api-key).
 
 ## Example: Proxy Service
+
 `twilio_proxy_service` provides a Twilio Proxy Service resource.
 Twilio Proxy Service is the top-level scope of all other resources in the Proxy Service REST API.
 
 ### Usage:
+
 ```hcl-terraform
 resource "twilio_proxy_service" "default" {
   unique_name = "Unique Proxy Service"
@@ -73,6 +83,7 @@ resource "twilio_proxy_service" "default" {
 ```
 
 ### Argument Reference
+
 - `unique_name` - An application-defined string that uniquely identifies the resource. This value must be 191 characters or fewer in length and be unique. This value should not have PII.
 - `default_ttl` - The default ttl value to set for Sessions created in the Service. The TTL (time to live) is measured in seconds after the Session's last create or last Interaction. The default value of 0 indicates an unlimited Session length. You can override a Session's default TTL value by setting its ttl value.
 - `callback_url` - The URL we should call when the interaction status changes.

--- a/usage.md
+++ b/usage.md
@@ -11,7 +11,7 @@ The provider needs to be configured with the proper credentials before it can be
 
 ## Example Usage
 
-```hcl-terraform
+```terraform
 # Configure the Twilio provider
 provider "twilio" {
   account_sid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 ### Usage
 
-```hcl-terraform
+```terraform
 resource "twilio_api_keys_v2010" "default" {
     account_sid = "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     friendly_name = "terraform key"
@@ -74,7 +74,7 @@ Twilio Proxy Service is the top-level scope of all other resources in the Proxy 
 
 ### Usage:
 
-```hcl-terraform
+```terraform
 resource "twilio_proxy_service" "default" {
   unique_name = "Unique Proxy Service"
   chat_instance_sid = "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"

--- a/usage.md
+++ b/usage.md
@@ -3,13 +3,16 @@
 The Twilio provider is used to interact with the resources supported by Twilio.
 The provider needs to be configured with the proper credentials before it can be used.
 
-- [Twilio Provider](#twilio-provider)
+- [Configuration](#configuration)
   - [Arguments](#arguments)
-  - [Example Usage](#example-usage)
-  - [Example: Create an API key](#example-create-an-api-key)
-  - [Example: Proxy Service](#example-proxy-service)
+  - [Specify an Edge Location](#specify-an-edge-location)
+  - [Specify a Subaccount](#specify-a-subaccount)
+- [Example: Create an API key](#example-create-an-api-key)
+- [Example: Proxy Service](#example-proxy-service)
 
-## Arguments
+## Configuration
+
+### Arguments
 
 The following arguments are supported:
 
@@ -19,7 +22,7 @@ The following arguments are supported:
 - `edge` - (Optional) The [Edge](https://www.twilio.com/docs/global-infrastructure/edge-locations#public-edge-locations) location to be used by the Twilio client. This can also be set via the `TWILIO_EDGE` environment variable.
 - `region` - (Optional) The [Region](https://www.twilio.com/docs/global-infrastructure/edge-locations/legacy-regions) to be used by the Twilio client. This can also be set via the `TWILIO_REGION` environment variable.
 
-## Example Usage
+#### Example Usage
 
 ```terraform
 # Configure the Twilio provider
@@ -39,13 +42,62 @@ resource "twilio_flex_flow" "default" {
 }
 ```
 
-then:
+then execute the following in your terminal:
 
 ```bash
+# Initialize a new or existing Terraform working directory
 $ terraform init
+# Generate a new infrastructure plan and create or update infrastructure accordingly
 $ terraform apply
-$ terraform destroy
 ```
+
+### Specify an Edge Location
+
+You can define the [Edge](https://www.twilio.com/docs/global-infrastructure/edge-locations#public-edge-locations) and/or [Region](https://www.twilio.com/docs/global-infrastructure/edge-locations/legacy-regions) by setting the environment variables TWILIO_EDGE and/or TWILIO_REGION. However, the resource configuration in your Terraform configuration file take precedence.
+
+```terraform
+provider "twilio" {
+  account_sid = "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  auth_token  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  region = "au1"
+  edge = "sydney"
+}
+```
+
+This will result in the hostname transforming from `api.twilio.com` to `api.sydney.au1.twilio.com`.
+
+A Twilio client constructed without these parameters will also look for TWILIO_REGION and TWILIO_EDGE variables inside the current environment.
+
+### Specify a Subaccount
+
+You can specify a subaccount to use with the provider by either setting the `TWILIO_SUBACCOUNT_SID` environment variable or explicitly passing it to the provider like so:
+
+```terraform
+provider "twilio" {
+  // account_sid defaults to TWILIO_ACCOUNT_SID env var
+  // auth_token  defaults to TWILIO_AUTH_TOKEN env var
+  // subaccount_sid  defaults to TWILIO_SUBACCOUNT_SID env var
+}
+```
+
+```terraform
+provider "twilio" {
+  account_sid    = "AC00112233445566778899aabbccddeefe"
+  auth_token    = "12345678123456781234567812345678"
+  subaccount_sid = "AC00112233445566778899aabbccddeeff"
+}
+```
+
+Alternatively, you can specify the subaccount to use at the resource level:
+
+```terraform
+resource "twilio_api_accounts_keys_v2010" "key_name" {
+  path_account_sid = "AC00112233445566778899aabbccddeeff"
+  friendly_name = "subaccount key"
+}
+```
+
+## Examples
 
 ## Example: Create an API Key
 

--- a/usage.md
+++ b/usage.md
@@ -65,7 +65,7 @@ $ terraform apply
 
 ### Specify an Edge Location
 
-You can define the [Edge](https://www.twilio.com/docs/global-infrastructure/edge-locations#public-edge-locations) and/or [Region](https://www.twilio.com/docs/global-infrastructure/edge-locations/legacy-regions) by setting the environment variables TWILIO_EDGE and/or TWILIO_REGION. However, the resource configuration in your Terraform configuration file take precedence.
+You can define the [Edge](https://www.twilio.com/docs/global-infrastructure/edge-locations#public-edge-locations) and/or [Region](https://www.twilio.com/docs/global-infrastructure/edge-locations/legacy-regions) by setting the environment variables `TWILIO_EDGE` and/or `TWILIO_REGION`. However, the resource configuration in your Terraform configuration file takes precedence.
 
 ```terraform
 provider "twilio" {
@@ -76,9 +76,9 @@ provider "twilio" {
 }
 ```
 
-This will result in the hostname transforming from `api.twilio.com` to `api.sydney.au1.twilio.com`.
+Setting this configuration will result in the Twilio client hostname transforming from `api.twilio.com` to `api.sydney.au1.twilio.com`.
 
-A Twilio client constructed without these parameters will also look for TWILIO_REGION and TWILIO_EDGE variables inside the current environment.
+A Twilio client constructed without these parameters will also look for `TWILIO_REGION` and `TWILIO_EDGE` variables inside the current environment.
 
 ### Specify a Subaccount
 

--- a/usage.md
+++ b/usage.md
@@ -4,10 +4,20 @@ The Twilio provider is used to interact with the resources supported by Twilio.
 The provider needs to be configured with the proper credentials before it can be used.
 
 - [Twilio Provider](#twilio-provider)
+  - [Arguments](#arguments)
   - [Example Usage](#example-usage)
-    - [Argument Reference](#argument-reference)
   - [Example: Create an API key](#example-create-an-api-key)
   - [Example: Proxy Service](#example-proxy-service)
+
+## Arguments
+
+The following arguments are supported:
+
+- `account_sid` - (Required) Twilio Account SID. This can also be set via the `TWILIO_ACCOUNT_SID` environment variable.
+- `auth_token` - (Required) Auth token for the account. This can also be set via the `TWILIO_AUTH_TOKEN` environment variable.
+- `subaccount_sid` - (Optional) Twilio Subaccount SID. This can also be set via the `TWILIO_SUBACCOUNT_SID` environment variable.
+- `edge` - (Optional) The [Edge](https://www.twilio.com/docs/global-infrastructure/edge-locations#public-edge-locations) location to be used by the Twilio client. This can also be set via the `TWILIO_EDGE` environment variable.
+- `region` - (Optional) The [Region](https://www.twilio.com/docs/global-infrastructure/edge-locations/legacy-regions) to be used by the Twilio client. This can also be set via the `TWILIO_REGION` environment variable.
 
 ## Example Usage
 
@@ -37,13 +47,6 @@ $ terraform apply
 $ terraform destroy
 ```
 
-### Argument Reference
-
-The following arguments are supported:
-
-- `account_sid` - (Required) Twilio Account SID. This can also be set via the `ACCOUNT_SID` environment variable.
-- `auth_token` - (Required) Auth token for the account. This can also be set via the `AUTH_TOKEN` environment variable.
-
 ## Example: Create an API Key
 
 `twilio_api_incoming_phone_numbers_v2010` provides a Twilio Phone Number resource.
@@ -72,7 +75,7 @@ For more information see [the API Key documentation](https://www.twilio.com/docs
 `twilio_proxy_service` provides a Twilio Proxy Service resource.
 Twilio Proxy Service is the top-level scope of all other resources in the Proxy Service REST API.
 
-### Usage:
+### Usage
 
 ```terraform
 resource "twilio_proxy_service" "default" {


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Docs #

- Making a pass at cleaning up the examples in the current README, bringing them together under the existing usage.md file, and organizing things
- Fix broken syntax highlighting in usage.md
- Clarifying provider arguments
- General markdown linting

This is just an idea. I think usage.md is a pretty old file, and if it's not in use I can probably just port the new table of contents, etc back into the README if you feel that's more appropriate.