### PR TITLE
fix: convert ints in path params to properly be imported

### DIFF
--- a/core/types.go
+++ b/core/types.go
@@ -5,3 +5,7 @@ import "strconv"
 func IntToString(input int) string {
 	return strconv.Itoa(input)
 }
+
+func StringToInt(input string) (int, error) {
+	return strconv.Atoi(input)
+}

--- a/core/types_test.go
+++ b/core/types_test.go
@@ -11,3 +11,20 @@ func TestIntToString(t *testing.T) {
 	assert.Equal(t, "0", IntToString(0))
 	assert.Equal(t, "-123", IntToString(-123))
 }
+
+func TestStringToInt(t *testing.T) {
+	value, err := StringToInt("123")
+	assert.Nil(t, err)
+	assert.Equal(t, 123, value)
+
+	value, err = StringToInt("0")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, value)
+
+	value, err = StringToInt("-123")
+	assert.Nil(t, err)
+	assert.Equal(t, -123, value)
+
+	_, err = StringToInt("blurg")
+	assert.NotNil(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/twilio/twilio-go v0.11.0
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	golang.org/x/tools v0.1.4 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210630183607-d20f26d13c79 // indirect
 	google.golang.org/grpc v1.39.0 // indirect

--- a/twilio/resources/accounts/v1/api_default.go
+++ b/twilio/resources/accounts/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/api/v2010/api_default.go
+++ b/twilio/resources/api/v2010/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/autopilot/v1/api_default.go
+++ b/twilio/resources/autopilot/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/chat/v1/api_default.go
+++ b/twilio/resources/chat/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/chat/v2/api_default.go
+++ b/twilio/resources/chat/v2/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/conversations/v1/api_default.go
+++ b/twilio/resources/conversations/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/events/v1/api_default.go
+++ b/twilio/resources/events/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/fax/v1/api_default.go
+++ b/twilio/resources/fax/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/flex/v1/api_default.go
+++ b/twilio/resources/flex/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/ip_messaging/v1/api_default.go
+++ b/twilio/resources/ip_messaging/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/ip_messaging/v2/api_default.go
+++ b/twilio/resources/ip_messaging/v2/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/messaging/v1/api_default.go
+++ b/twilio/resources/messaging/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/notify/v1/api_default.go
+++ b/twilio/resources/notify/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/numbers/v2/api_default.go
+++ b/twilio/resources/numbers/v2/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/proxy/v1/api_default.go
+++ b/twilio/resources/proxy/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/serverless/v1/api_default.go
+++ b/twilio/resources/serverless/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/studio/v1/api_default.go
+++ b/twilio/resources/studio/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/studio/v2/api_default.go
+++ b/twilio/resources/studio/v2/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/sync/v1/api_default.go
+++ b/twilio/resources/sync/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 
@@ -482,7 +482,11 @@ func parseServicesListsItemsImportId(importId string, d *schema.ResourceData) er
 
 	d.Set("service_sid", importParts[0])
 	d.Set("list_sid", importParts[1])
-	d.Set("index", importParts[2])
+	index, err := StringToInt(importParts[2])
+	if err != nil {
+		return nil
+	}
+	d.Set("index", index)
 
 	return nil
 }

--- a/twilio/resources/taskrouter/v1/api_default.go
+++ b/twilio/resources/taskrouter/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/trunking/v1/api_default.go
+++ b/twilio/resources/trunking/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/trusthub/v1/api_default.go
+++ b/twilio/resources/trusthub/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/verify/v2/api_default.go
+++ b/twilio/resources/verify/v2/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/video/v1/api_default.go
+++ b/twilio/resources/video/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/voice/v1/api_default.go
+++ b/twilio/resources/voice/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 

--- a/twilio/resources/wireless/v1/api_default.go
+++ b/twilio/resources/wireless/v1/api_default.go
@@ -3,7 +3,7 @@
  *
  * This is the public Twilio REST API.
  *
- * API version: 1.18.1
+ * API version: 1.18.0
  * Contact: support@twilio.com
  */
 


### PR DESCRIPTION
Only impacts `sync`.

https://github.com/twilio/twilio-oai-generator/pull/81