### PR TITLE
feat: Added domain_name as a computed output variable to the Serverless

### DIFF
--- a/twilio/resources/serverless/v1/README.md
+++ b/twilio/resources/serverless/v1/README.md
@@ -32,6 +32,7 @@ Name | Type | Requirement | Description
 **unique_name** | string | **Required** | A user-defined string that uniquely identifies the Environment resource. It can be a maximum of 100 characters.
 **domain_suffix** | string | Optional | A URL-friendly name that represents the environment and forms part of the domain name. It can be a maximum of 16 characters.
 **sid** | string | *Computed* | The SID of the Environment resource to fetch.
+**domain_name** | string | *Computed* | The domain name generated for use by external callers to reach functions running in this environment, e.g. 'myservice-1234-myenvironment.twil.io'.
 
 ## twilio_serverless_services_functions_v1
 

--- a/twilio/resources/serverless/v1/api_default.go
+++ b/twilio/resources/serverless/v1/api_default.go
@@ -247,6 +247,7 @@ func ResourceServicesEnvironments() *schema.Resource {
 			"unique_name":   AsString(SchemaForceNewRequired),
 			"domain_suffix": AsString(SchemaForceNewOptional),
 			"sid":           AsString(SchemaComputed),
+			"domain_name":   AsString(SchemaComputed),
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {

--- a/twilio/resources_serverless_test.go
+++ b/twilio/resources_serverless_test.go
@@ -39,6 +39,7 @@ func TestAccServerlessSetup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(serverlessSvcResourceName, "unique_name", serviceName),
 					resource.TestCheckResourceAttr(serverlessSvcFuncResourceName, "friendly_name", "Serverless func"),
 					resource.TestCheckResourceAttr(serverlessSvcEnvResourceName, "unique_name", "environment-dummy"),
+					resource.TestCheckResourceAttrSet(serverlessSvcEnvResourceName, "domain_name"),
 				),
 			},
 			{
@@ -49,6 +50,7 @@ func TestAccServerlessSetup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(serverlessSvcResourceName, "unique_name", serviceName),
 					resource.TestCheckResourceAttr(serverlessSvcFuncResourceName, "friendly_name", "Serverless func 2"),
 					resource.TestCheckResourceAttr(serverlessSvcEnvResourceName, "unique_name", "environment-dummy-updated"),
+					resource.TestCheckResourceAttrSet(serverlessSvcEnvResourceName, "domain_name"),
 					testAccEnvResourceWasRecreated(&serviceBefore, &serviceAfter),
 				),
 			},


### PR DESCRIPTION
# Resolves #85 #

Adds a `domain_name` output variable to the Serverless Environment resource. This can then be passed to other resources that need to be configured to call the functions deployed in this environment.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [?] I have read the [Contribution Guidelines](https://github.com/twilio/terraform-provider-twilio/blob/main/CONTRIBUTING.md) and my PR follows them - that is a dead link?
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [N/A] I have added inline documentation to the code I modified
