### PR TITLE
fix: unpack the interface type when marshaling response schemas

### DIFF
--- a/core/provider_marshal.go
+++ b/core/provider_marshal.go
@@ -446,12 +446,9 @@ func marshallNode(setter func(string, interface{}) error, fieldName string, fiel
 		if fieldValue.IsNil() {
 			return setter(fieldName, nil)
 		}
-		// free form json
-		byteValue, err := json.Marshal(fieldValue.Interface().(map[string]interface{}))
-		if err != nil {
-			return WrapErrorGeneric(err, "Json marshaling failed for field "+fieldName)
-		}
-		if err := setter(fieldName, string(byteValue)); err != nil {
+
+		value := fieldValue.Interface()
+		if err := marshallNode(setter, fieldName, reflect.TypeOf(value), reflect.ValueOf(value), flatten); err != nil {
 			return err
 		}
 

--- a/core/provider_marshal_test.go
+++ b/core/provider_marshal_test.go
@@ -998,8 +998,7 @@ func TestImplicitNestedMarshal(t *testing.T) {
 		Notifications *map[string]interface{} `json:"notifications"`
 	}
 
-	var recipient interface{}
-	recipient = map[string]interface{}{
+	var recipient interface{} = map[string]interface{}{
 		"first_name": "Turk",
 		"last_name":  "Andjaydee",
 		"email":      nil,

--- a/core/provider_marshal_test.go
+++ b/core/provider_marshal_test.go
@@ -998,6 +998,13 @@ func TestImplicitNestedMarshal(t *testing.T) {
 		Notifications *map[string]interface{} `json:"notifications"`
 	}
 
+	var recipient interface{}
+	recipient = map[string]interface{}{
+		"first_name": "Turk",
+		"last_name":  "Andjaydee",
+		"email":      nil,
+	}
+
 	testStruct := innerStruct{
 		Limits: &map[string]interface{}{
 			"channel_members": 10,
@@ -1005,11 +1012,7 @@ func TestImplicitNestedMarshal(t *testing.T) {
 		Notifications: &map[string]interface{}{
 			"log_enabled":       true,
 			"new_message_sound": "LOUD NOISES!",
-			"recipient": &map[string]interface{}{
-				"first_name": "Turk",
-				"last_name":  "Andjaydee",
-				"email":      nil,
-			},
+			"recipient":         &recipient,
 		},
 	}
 	if err := MarshalSchema(resourceData, &testStruct); err != nil {


### PR DESCRIPTION
Fixes this broken test:
```
=== RUN   TestAccFlexSetup_basic
    resources_flex_test.go:23: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) {
        }
        
        
        (map[string]string) (len=1) {
         (string) (len=20) "integration_flow_sid": (string) (len=34) "FW9bda0c9a02677aeabcc7c770b3469b83"
        }
--- FAIL: TestAccFlexSetup_basic (5.05s)
```